### PR TITLE
chore: migrate github-actions updates from dependabot to renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
----
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,32 @@
+// This file follows JSON5 syntax, to make it
+// easier to maintain.
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  // Disable every built-in manager (npm, dockerfile, ...) except github-actions.
+  enabledManagers: ["github-actions"],
+  // PR titles use Conventional Commits: `deps(<action>): ...`
+  semanticCommits: "enabled",
+  semanticCommitType: "deps",
+  packageRules: [
+    // GitHub Actions updates: run weekly, skip releases newer than 2 weeks
+    // to avoid picking up freshly published versions that may be unstable or
+    // compromised, and pin to full commit SHAs (with the version as a
+    // trailing comment) rather than mutable tags.
+    // When both major and minor releases exist, propose only the latest bump
+    // (typically major) instead of a separate minor PR.
+    {
+      matchManagers: ["github-actions"],
+      schedule: ["on monday"],
+      minimumReleaseAge: "14 days",
+      // Track upgrades by semver tag, but pin the resolved version to its full
+      // commit SHA (semver tag kept as a trailing comment). Use the coerced
+      // variant so short tags like `v3` / `v1.7` (which several actions only
+      // publish) still parse instead of silently stopping updates.
+      versioning: "semver-coerced",
+      pinDigests: true,
+      separateMajorMinor: false,
+      semanticCommitScope: "{{depName}}",
+      commitMessageTopic: "{{depName}}",
+    },
+  ],
+}


### PR DESCRIPTION
Replaces Dependabot with Renovate for GitHub Actions updates:

- adds `.github/renovate.json5` (github-actions-only: weekly, 2-week-aged, SHA-pinned bumps with Conventional Commit `deps(<action>):` titles)
- removes `.github/dependabot.yml`

Open Dependabot PRs on this repo were closed as part of the migration.