### PR TITLE
Add Fast Paths support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A Python library for validating CoW Protocol settlement transactions. This libra
 The Competition Monitoring library enforces three main validation rules for settlement transactions:
 
 1. **Solver Identity Verification** - Ensures the on-chain settlement was submitted by the winning solver
-2. **Order Validation** - Validates trade execution, amounts, and surplus rules
+2. **Order Validation** - Validates that executed trades match what was proposed in the bid
+3. **Hook Validation** - Validates that pre/post hooks declared in appData were executed
 
 ## Core Components
 
@@ -23,9 +24,7 @@ The Competition Monitoring library enforces three main validation rules for sett
   - `auction_id`: Auction identifier
   - `solver`: Winning solver address
   - `trades`: List of proposed trades
-  - `valid_orders`: Set of valid order UIDs
-  - `jit_order_addresses`: Whitelisted JIT order addresses
-  - `native_prices`: Token prices in native currency
+  - `order_hooks`: Dict mapping order_uid to expected hooks for that order
 
 - **`OnchainTrade`** - Executed trade data
 - **`OffchainTrade`** - Proposed trade data
@@ -42,10 +41,9 @@ Main validation orchestrator that runs all checks. Raises `InvalidSettlement` if
   - Validates solver address matches between on-chain and off-chain data
 
 - **`check_orders(onchain_data, offchain_data) -> bool`**
-  - Performs three ordered checks:
+  - Performs two ordered checks:
     1. **1-to-1 Mapping** - Executed trades must exactly match proposed trades
     2. **Amount Matching** - Sell/buy amounts must match between execution and proposal
-    3. **Surplus Validation** - Orders with surplus must be valid or whitelisted JIT orders
 
 ### Exceptions (`exceptions.py`)
 
@@ -82,11 +80,6 @@ The library enforces strict 1-to-1 trade mapping:
 - `onchain.buy_amount == offchain.buy_amount`
 - No deviation allowed from proposed amounts
 
-#### 2c. Surplus Validation
-- Orders with non-zero surplus must either:
-  - Be part of the auction (in `valid_orders`), OR
-  - Have whitelisted JIT order owner (in `jit_order_addresses`)
-
 ## Integration Guide
 
 To use this library in a monitoring system like Circuit Breaker, you need to provide:
@@ -101,9 +94,7 @@ Implement a component to fetch settlement data from blockchain:
 Implement a component to fetch auction data:
 - Winning solver and solution details
 - Proposed trades and amounts
-- Fee policies for each order
-- Valid order UIDs and JIT order addresses
-- Native token prices
+- Hooks declared for each order (for `check_hooks`)
 
 ### 3. Settlement Processor
 Use the library's `inspect()` function to validate settlements:
@@ -153,11 +144,10 @@ offchain_data = OffchainSettlementData(
             order_uid=HexBytes("0xORDER_UID"),
             sell_amount=1000000,
             buy_amount=2000000,
+            already_executed_amount=0,
         )
     ],
-    valid_orders={HexBytes("0xORDER_UID")},
-    jit_order_addresses=set(),
-    native_prices={HexBytes("0xTOKEN_B"): 1000000000000000000},
+    order_hooks={},
 )
 
 # Validate settlement

--- a/circuit_breaker_validator/check_tx.py
+++ b/circuit_breaker_validator/check_tx.py
@@ -62,16 +62,12 @@ def check_orders(
 ) -> bool:
     """Check orders of the settlement
 
-    Performs three validation checks in order:
+    Performs two validation checks in order:
     1. 1-to-1 mapping between executed and proposed trades
        - All executed trades must have been proposed in the bid
        - All JIT orders must be revealed in the bidding phase
     2. Executed amounts match proposed amounts
        - Sell and buy amounts must match exactly between on-chain and off-chain
-    3. Surplus validation for non-standard orders
-       - Orders with non-zero surplus either:
-         - were part of the auction (normal order), OR
-         - have a surplus capturing jit order owner (cow amm order)
     """
     onchain_trades_dict = {trade.order_uid: trade for trade in onchain_data.trades}
     offchain_trades_dict = {trade.order_uid: trade for trade in offchain_data.trades}
@@ -101,19 +97,6 @@ def check_orders(
                 f"Off-chain trade: {offchain_trade}"
             )
             return False
-
-    # Check 3: surplus validation for non-standard orders
-    for order_uid, onchain_trade in onchain_trades_dict.items():
-        if onchain_trade.surplus() > 0:
-            if (
-                order_uid not in offchain_data.valid_orders
-                and onchain_trade.owner not in offchain_data.jit_order_addresses
-            ):
-                logger.error(
-                    f"Transaction hash {onchain_data.tx_hash!r}: "
-                    f"Non-CoW AMM JIT order with non-zero surplus: {order_uid!r}"
-                )
-                return False
 
     return True
 

--- a/circuit_breaker_validator/models.py
+++ b/circuit_breaker_validator/models.py
@@ -121,21 +121,12 @@ class OffchainSettlementData:
         auction_id: Unique identifier for the auction
         solver: Address of the solver that submitted the settlement
         trades: List of trades proposed in the settlement
-        valid_orders: Set of order_uids that were valid in the auction
-        jit_order_addresses: Set of addresses that are JIT order owners
-        native_prices: Dict mapping token addresses to their native prices
         order_hooks: Dict mapping order_uid to Hooks for that order.
             May contain entries for orders not in this settlement without causing issues.
     """
-
-    # pylint: disable=too-many-instance-attributes
 
     auction_id: int
     # solution data
     solver: HexBytes
     trades: list[OffchainTrade]
-    # auction data
-    valid_orders: set[HexBytes]
-    jit_order_addresses: set[HexBytes]
-    native_prices: dict[HexBytes, int]
     order_hooks: dict[HexBytes, Hooks]

--- a/tests/test_check_tx.py
+++ b/tests/test_check_tx.py
@@ -44,16 +44,14 @@ def test_check_solver(onchain_solver, offchain_solver, expected_result):
 @pytest.mark.parametrize(
     "scenario,expected_result",
     [
-        # JIT order with zero surplus - now fails due to 1-to-1 mapping requirement
-        ("jit_order_zero_surplus_not_revealed", False),
-        # JIT order with zero surplus that was revealed - should pass
-        ("jit_order_zero_surplus_revealed", True),
-        # JIT order with non-zero surplus
-        ("jit_order_nonzero_surplus", False),
-        # JIT order with matching amounts (CoW AMM)
-        ("jit_order_matching_amounts", True),
-        # Regular order with matching amounts
-        ("regular_order_matching_amounts", True),
+        # Order with zero surplus that was not revealed - fails due to 1-to-1 mapping requirement
+        ("zero_surplus_not_revealed", False),
+        # Order with zero surplus that was revealed - should pass
+        ("zero_surplus_revealed", True),
+        # Order with non-zero surplus that was not revealed
+        ("nonzero_surplus_not_revealed", False),
+        # Order with matching amounts and non-zero surplus - should pass
+        ("matching_amounts_with_surplus", True),
         # Order with mismatched buy amount
         ("mismatched_buy_amount", False),
         # Order with mismatched sell amount
@@ -79,11 +77,9 @@ def test_check_orders(scenario, expected_result):
     sell_amount = 10**25
     buy_amount = 99 * 10**25
 
-    if scenario == "jit_order_zero_surplus_not_revealed":
-        # JIT order with zero surplus that was not revealed - fails 1-to-1 mapping
+    if scenario == "zero_surplus_not_revealed":
+        # Order with zero surplus that was not revealed - fails 1-to-1 mapping
         owner = HexBytes("0x11")
-        valid_orders = set()
-        jit_order_addresses = {HexBytes("0x12")}
 
         trade = Mock(spec=OnchainTrade)
         trade.order_uid = order_uid
@@ -96,14 +92,10 @@ def test_check_orders(scenario, expected_result):
 
         offchain_data = Mock(spec=OffchainSettlementData)
         offchain_data.trades = []
-        offchain_data.valid_orders = valid_orders
-        offchain_data.jit_order_addresses = jit_order_addresses
 
-    elif scenario == "jit_order_zero_surplus_revealed":
-        # JIT order with zero surplus that was revealed - passes
+    elif scenario == "zero_surplus_revealed":
+        # Order with zero surplus that was revealed - passes
         owner = HexBytes("0x11")
-        valid_orders = set()
-        jit_order_addresses = {HexBytes("0x12")}
 
         onchain_trade = Mock(spec=OnchainTrade)
         onchain_trade.order_uid = order_uid
@@ -124,14 +116,10 @@ def test_check_orders(scenario, expected_result):
 
         offchain_data = Mock(spec=OffchainSettlementData)
         offchain_data.trades = [offchain_trade]
-        offchain_data.valid_orders = valid_orders
-        offchain_data.jit_order_addresses = jit_order_addresses
 
-    elif scenario == "jit_order_nonzero_surplus":
-        # JIT order with non-zero surplus
+    elif scenario == "nonzero_surplus_not_revealed":
+        # Order with non-zero surplus that was not revealed - fails 1-to-1 mapping
         owner = HexBytes("0x11")
-        valid_orders = set()
-        jit_order_addresses = {HexBytes("0x12")}
 
         trade = Mock(spec=OnchainTrade)
         trade.order_uid = order_uid
@@ -144,14 +132,11 @@ def test_check_orders(scenario, expected_result):
 
         offchain_data = Mock(spec=OffchainSettlementData)
         offchain_data.trades = []
-        offchain_data.valid_orders = valid_orders
-        offchain_data.jit_order_addresses = jit_order_addresses
 
-    elif scenario == "jit_order_matching_amounts":
-        # JIT order with matching amounts
+    elif scenario == "matching_amounts_with_surplus":
+        # Order with matching amounts and non-zero surplus - passes
+        # (surplus is no longer restricted to whitelisted/auction orders)
         owner = HexBytes("0x11")
-        valid_orders = set()
-        jit_order_addresses = {HexBytes("0x11")}
 
         onchain_trade = Mock(spec=OnchainTrade)
         onchain_trade.order_uid = order_uid
@@ -172,42 +157,10 @@ def test_check_orders(scenario, expected_result):
 
         offchain_data = Mock(spec=OffchainSettlementData)
         offchain_data.trades = [offchain_trade]
-        offchain_data.valid_orders = valid_orders
-        offchain_data.jit_order_addresses = jit_order_addresses
-
-    elif scenario == "regular_order_matching_amounts":
-        # Regular order with matching amounts
-        owner = HexBytes("0x12")
-        valid_orders = {order_uid}
-        jit_order_addresses = {HexBytes("0x11")}
-
-        onchain_trade = Mock(spec=OnchainTrade)
-        onchain_trade.order_uid = order_uid
-        onchain_trade.owner = owner
-        onchain_trade.sell_amount = sell_amount
-        onchain_trade.buy_amount = buy_amount
-        onchain_trade.surplus = Mock(return_value=1)
-
-        offchain_trade = Mock(spec=OffchainTrade)
-        offchain_trade.order_uid = order_uid
-        offchain_trade.owner = owner
-        offchain_trade.sell_amount = sell_amount
-        offchain_trade.buy_amount = buy_amount
-
-        onchain_data = Mock(spec=OnchainSettlementData)
-        onchain_data.tx_hash = tx_hash
-        onchain_data.trades = [onchain_trade]
-
-        offchain_data = Mock(spec=OffchainSettlementData)
-        offchain_data.trades = [offchain_trade]
-        offchain_data.valid_orders = valid_orders
-        offchain_data.jit_order_addresses = jit_order_addresses
 
     elif scenario == "mismatched_buy_amount":
         # Order with mismatched buy amount
         owner = HexBytes("0x12")
-        valid_orders = {order_uid}
-        jit_order_addresses = {HexBytes("0x11")}
 
         onchain_trade = Mock(spec=OnchainTrade)
         onchain_trade.order_uid = order_uid
@@ -228,14 +181,10 @@ def test_check_orders(scenario, expected_result):
 
         offchain_data = Mock(spec=OffchainSettlementData)
         offchain_data.trades = [offchain_trade]
-        offchain_data.valid_orders = valid_orders
-        offchain_data.jit_order_addresses = jit_order_addresses
 
     elif scenario == "mismatched_sell_amount":
         # Order with mismatched sell amount
         owner = HexBytes("0x12")
-        valid_orders = {order_uid}
-        jit_order_addresses = {HexBytes("0x11")}
 
         onchain_trade = Mock(spec=OnchainTrade)
         onchain_trade.order_uid = order_uid
@@ -256,14 +205,10 @@ def test_check_orders(scenario, expected_result):
 
         offchain_data = Mock(spec=OffchainSettlementData)
         offchain_data.trades = [offchain_trade]
-        offchain_data.valid_orders = valid_orders
-        offchain_data.jit_order_addresses = jit_order_addresses
 
     elif scenario == "more_executed_than_proposed":
         # More executed trades than proposed (no 1-to-1 mapping)
         owner = HexBytes("0x12")
-        valid_orders = {order_uid}
-        jit_order_addresses = {HexBytes("0x11")}
         order_uid_2 = HexBytes("0x02")
 
         onchain_trade_1 = Mock(spec=OnchainTrade)
@@ -292,14 +237,10 @@ def test_check_orders(scenario, expected_result):
 
         offchain_data = Mock(spec=OffchainSettlementData)
         offchain_data.trades = [offchain_trade]
-        offchain_data.valid_orders = valid_orders
-        offchain_data.jit_order_addresses = jit_order_addresses
 
     elif scenario == "more_proposed_than_executed":
         # More proposed trades than executed (no 1-to-1 mapping)
         owner = HexBytes("0x12")
-        valid_orders = {order_uid}
-        jit_order_addresses = {HexBytes("0x11")}
         order_uid_2 = HexBytes("0x02")
 
         onchain_trade = Mock(spec=OnchainTrade)
@@ -327,14 +268,10 @@ def test_check_orders(scenario, expected_result):
 
         offchain_data = Mock(spec=OffchainSettlementData)
         offchain_data.trades = [offchain_trade_1, offchain_trade_2]
-        offchain_data.valid_orders = valid_orders
-        offchain_data.jit_order_addresses = jit_order_addresses
 
     elif scenario == "executed_not_in_proposed":
         # Executed trade not in proposed trades
         owner = HexBytes("0x12")
-        valid_orders = {order_uid}
-        jit_order_addresses = {HexBytes("0x11")}
         order_uid_2 = HexBytes("0x02")
 
         onchain_trade = Mock(spec=OnchainTrade)
@@ -356,14 +293,10 @@ def test_check_orders(scenario, expected_result):
 
         offchain_data = Mock(spec=OffchainSettlementData)
         offchain_data.trades = [offchain_trade]
-        offchain_data.valid_orders = valid_orders
-        offchain_data.jit_order_addresses = jit_order_addresses
 
     elif scenario == "proposed_not_in_executed":
         # Proposed trade not in executed trades
         owner = HexBytes("0x12")
-        valid_orders = {order_uid}
-        jit_order_addresses = {HexBytes("0x11")}
         order_uid_2 = HexBytes("0x02")
 
         onchain_trade = Mock(spec=OnchainTrade)
@@ -385,17 +318,12 @@ def test_check_orders(scenario, expected_result):
 
         offchain_data = Mock(spec=OffchainSettlementData)
         offchain_data.trades = [offchain_trade]
-        offchain_data.valid_orders = valid_orders
-        offchain_data.jit_order_addresses = jit_order_addresses
 
     elif scenario == "multiple_trades_matching":
         # Multiple trades with correct 1-to-1 mapping
         owner = HexBytes("0x12")
-        valid_orders = {order_uid}
-        jit_order_addresses = {HexBytes("0x11")}
         order_uid_2 = HexBytes("0x02")
         order_uid_3 = HexBytes("0x03")
-        valid_orders = {order_uid, order_uid_2, order_uid_3}
 
         onchain_trade_1 = Mock(spec=OnchainTrade)
         onchain_trade_1.order_uid = order_uid
@@ -439,13 +367,9 @@ def test_check_orders(scenario, expected_result):
 
         offchain_data = Mock(spec=OffchainSettlementData)
         offchain_data.trades = [offchain_trade_1, offchain_trade_2, offchain_trade_3]
-        offchain_data.valid_orders = valid_orders
-        offchain_data.jit_order_addresses = jit_order_addresses
 
     elif scenario == "empty_trades_both_sides":
         # Empty trades on both sides - valid 1-to-1 mapping (no trades)
-        valid_orders = set()
-        jit_order_addresses = set()
 
         onchain_data = Mock(spec=OnchainSettlementData)
         onchain_data.tx_hash = tx_hash
@@ -453,8 +377,6 @@ def test_check_orders(scenario, expected_result):
 
         offchain_data = Mock(spec=OffchainSettlementData)
         offchain_data.trades = []
-        offchain_data.valid_orders = valid_orders
-        offchain_data.jit_order_addresses = jit_order_addresses
 
     assert check_orders(onchain_data, offchain_data) == expected_result
 


### PR DESCRIPTION
Remove surplus validation check for non-standard orders.

The check relied on auction-level data (valid_orders, jit_order_addresses, native_prices) that is being dropped from OffchainSettlementData now that the AWS auction dump is no longer fetched. Order validation is now limited to the 1-to-1 trade mapping and amount matching checks.